### PR TITLE
No arguments for read_data.py

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -7,6 +7,6 @@ module.exports = [{
     script: 'python/read_data.py',
     name: 'python',
     interpreter: "/usr/bin/python3",
-    args: "python python/read_data.py test_files/20190524_Run1_TMA-H2O-50cycles_TMA-10Pulses_TMA-H2O-20cycles_425C_GaPO4_Doses-DeltaM.txt test_files/20190524_Run1_TMA-H2O-50cycles_TMA-10Pulses_TMA-H2O-20cycles_425C_GaPO4_DataLog.txt test_files/20190524_Run1_TMA-H2O-50cycles_TMA-10Pulses_TMA-H2O-20cycles_425C_GaPO4_ExecutionTable.txt test_files/20190524_Run1_TMA-H2O-50cycles_TMA-10Pulses_TMA-H2O-20cycles_425C_GaPO4_Summary.txt"
+    args: ""
   }
 ];

--- a/python/read_data.py
+++ b/python/read_data.py
@@ -34,10 +34,10 @@ class ReadData:
         """
         # Get the path of current working directory, currently works for just test_files
         # TODO (Future Story) Continue Path checking to determine development environment
-        path_adder_1 = "\\test_files"  # Defaults to test_files, will start implementing after Task #50 is completed
+        path_adder_1 = "/test_files"  # Defaults to test_files, will start implementing after Task #50 is completed
         path_adder_2 = "test_files/"
         if test is not None:
-            path_adder_1 = "\\test_files"
+            path_adder_1 = "/test_files"
             path_adder_2 = "test_files/"
         my_path = pathlib.Path().absolute()
         my_path = (str(my_path) + path_adder_1)

--- a/python/read_data.py
+++ b/python/read_data.py
@@ -1,6 +1,9 @@
 import re
 import sys
 import pandas as pd
+from os import listdir
+from os.path import isfile, join
+import pathlib
 
 
 class ReadData:
@@ -24,20 +27,34 @@ class ReadData:
     -------
     Each attribute has its own getter method used to retrieve the passed in file
     """
-    def __init__(self, args):
+    def __init__(self, test=None):
         """
 
-        :param args: A list of files to be processed and collect data from
+        :param test: Attach any value to run test files.
         """
-        for arg in args:
-            if re.search("Doses-DeltaM.txt", arg):
-                self.doses_deltaM = re.search("Doses-DeltaM.txt", arg)
-            if re.search("DataLog.txt", arg):
-                self.data_log = re.search("DataLog.txt", arg)
-            if re.search("ExecutionTable.txt", arg):
-                self.exe_table = re.search("ExecutionTable.txt", arg)
-            if re.search("Summary.txt", arg):
-                self.summary = re.search("Summary.txt", arg)
+        # Get the path of current working directory, currently works for just test_files
+        # TODO (Future Story) Continue Path checking to determine development environment
+        path_adder_1 = "\\test_files"  # Defaults to test_files, will start implementing after Task #50 is completed
+        path_adder_2 = "test_files/"
+        if test is not None:
+            path_adder_1 = "\\test_files"
+            path_adder_2 = "test_files/"
+        my_path = pathlib.Path().absolute()
+        my_path = (str(my_path) + path_adder_1)
+        data_files = []
+        # tmp files to add appropriate additional path files for environment
+        tmp_data_files = [f for f in listdir(my_path) if isfile(join(my_path, f))]
+        for f in tmp_data_files:
+            data_files.append(path_adder_2 + (str(f)))
+        for f in data_files:
+            if re.search("Doses-DeltaM.txt", f):
+                self.doses_deltaM = re.search("Doses-DeltaM.txt", f)
+            if re.search("DataLog.txt", f):
+                self.data_log = re.search("DataLog.txt", f)
+            if re.search("ExecutionTable.txt", f):
+                self.exe_table = re.search("ExecutionTable.txt", f)
+            if re.search("Summary.txt", f):
+                self.summary = re.search("Summary.txt", f)
 
     def get_doses_delta(self):
         """
@@ -107,10 +124,9 @@ def get_summary(file):
 def main(args):
     """
     The starting point of the program.
-    :param args: A list of ALD data files to be processed
     :return:
     """
-    read_data = ReadData(sys.argv)
+    read_data = ReadData()
     data_log_df = get_file_df(read_data.get_data_log())
     exe_table_df = get_file_df(read_data.get_exe_table())
     doses_delta_df = get_file_df(read_data.get_doses_delta())

--- a/python/test_read_data_unittest.py
+++ b/python/test_read_data_unittest.py
@@ -10,7 +10,7 @@ files = ["test_files/20190524_Run1_TMA-H2O-50cycles_TMA-10Pulses_TMA-H2O-20cycle
          "test_files/20190524_Run1_TMA-H2O-50cycles_TMA-10Pulses_TMA-H2O-20cycles_425C_GaPO4_ExecutionTable.txt",
          "test_files/20190524_Run1_TMA-H2O-50cycles_TMA-10Pulses_TMA-H2O-20cycles_425C_GaPO4_Summary.txt"]
 
-read_data = ReadData(files)
+read_data = ReadData(1)
 data_log_df = get_file_df(read_data.get_data_log())
 data_log_columns = ['Timestamp', 'Elapsed Time [s]', 'Chamber Pressure [Torr]', 'Pump Pressure [Torr]',
                     'Xtal OK? [0=F, 1=T]', 'Xtal Life [%]', 'Mass [ng/cm²]', 'Mass Offset [ng/cm²] ',


### PR DESCRIPTION
Closes #46

Script, read_data.py, can now run without command line arguments. It also allows the optional argument that allows read_data to read the test files instead of retrieval of up to date files (to be implemented in future task).